### PR TITLE
Add RSI tests and edge case handling

### DIFF
--- a/stock.py
+++ b/stock.py
@@ -1,8 +1,4 @@
-from datetime import date
-import yfinance as yf
 import pandas as pd
-import matplotlib.pyplot as plt
-import copy
 
 # Moving Avg
 def getMovingAvg(values, gap):
@@ -13,101 +9,114 @@ def getMovingAvg(values, gap):
 def rsi(i):
     up = i[i > 0].mean()
     down = -1 * i[i < 0].mean()
-    return 100 * up / (up + down)
+    if pd.isna(up):
+        up = 0
+    if pd.isna(down):
+        down = 0
+    total = up + down
+    if total == 0:
+        return 0
+    return 100 * up / total
 
 
-# Define stock & date
-stock = ["TSLA", "MSFT"]
-start_date = "2020-01-01"
-end_date = "2021-01-01"
+if __name__ == "__main__":
+    from datetime import date
+    import yfinance as yf
+    import matplotlib.pyplot as plt
+    import copy
 
-# Download .csv
-for v in stock:
-    data = yf.download(v, start_date, end_date)
-    data.to_csv("./Stocks/" + v + ".csv")
+    # Define stock & date
+    stock = ["TSLA", "MSFT"]
+    start_date = "2020-01-01"
+    end_date = "2021-01-01"
 
-dates = pd.date_range(start_date, end_date)
-dataFrame = pd.DataFrame(index=dates)
+    # Download .csv
+    for v in stock:
+        data = yf.download(v, start_date, end_date)
+        data.to_csv("./Stocks/" + v + ".csv")
 
-# Put in a frame
-for v in stock:
-    data = pd.read_csv(
-        "./Stocks/" + v + ".csv",
-        index_col="Date",
-        parse_dates=True,
-        usecols=["Date", "Close"],
-        na_values=["nan"],
-    )
-    data = data.rename(columns={"Close": v})
+    dates = pd.date_range(start_date, end_date)
+    dataFrame = pd.DataFrame(index=dates)
 
-    dataFrame = dataFrame.join(data)
-    dataFrame = dataFrame.dropna()
+    # Put in a frame
+    for v in stock:
+        data = pd.read_csv(
+            "./Stocks/" + v + ".csv",
+            index_col="Date",
+            parse_dates=True,
+            usecols=["Date", "Close"],
+            na_values=["nan"],
+        )
+        data = data.rename(columns={"Close": v})
 
-# Graph
-mergedPlot = dataFrame.plot(title="Stock Prices")
-mergedPlot.set_xlabel("Date")
-mergedPlot.set_ylabel("Price")
-plt.show()
+        dataFrame = dataFrame.join(data)
+        dataFrame = dataFrame.dropna()
 
-normalized = dataFrame / dataFrame.iloc[0, :]
-
-mergedPlot = normalized.plot(title="Normalized")
-mergedPlot.set_xlabel("Date")
-mergedPlot.set_ylabel("Price")
-plt.show()
-
-# Moving Avg Graph
-for v in stock:
-    ax = dataFrame[v].plot(title=v + " moving average", label=v)
-    ax.set_xlabel("Date")
-    ax.set_ylabel("Price")
-
-    avg = getMovingAvg(dataFrame[v], gap=20)
-    avg.plot(label="Moving Avg", ax=ax)
+    # Graph
+    mergedPlot = dataFrame.plot(title="Stock Prices")
+    mergedPlot.set_xlabel("Date")
+    mergedPlot.set_ylabel("Price")
     plt.show()
 
-frame = copy.deepcopy(dataFrame)
+    normalized = dataFrame / dataFrame.iloc[0, :]
 
-for v in stock:
-    # Avg
-    avg = getMovingAvg(dataFrame[v], gap=20)
-
-    # Standard Deviation
-    std = dataFrame[v].rolling(20).std()
-    largeAvg = getMovingAvg(dataFrame[v], gap=50)
-    dataFrame["MovingAvg_" + v] = avg
-    dataFrame["Avg" + v] = largeAvg
-    dataFrame["RollStd_" + v] = std
-
-    # Bollinger Bands Limits (2*standard deviation, 20 as period)
-    up = avg + std * 2
-    low = avg - std * 2
-    dataFrame["Up_" + v] = up
-    dataFrame["Low_" + v] = low
-
-for v in stock:
-    ax = dataFrame.plot(title="Bollinger Bands", label=v)
-    up.plot(label="up -", ax=ax)
-    low.plot(label="low -", ax=ax)
-    avg.plot(label="RollingMean", ax=ax)
-    ax.set_xlabel("Date")
-    ax.set_ylabel("Price")
+    mergedPlot = normalized.plot(title="Normalized")
+    mergedPlot.set_xlabel("Date")
+    mergedPlot.set_ylabel("Price")
     plt.show()
 
-for v in stock:
-    daily = (dataFrame[v] / dataFrame[v].shift(1)) - 1
-    dataFrame["Daily_" + v] = daily
-    ax = daily.plot(title="Daily " + v, label=v)
-    plt.show()
+    # Moving Avg Graph
+    for v in stock:
+        ax = dataFrame[v].plot(title=v + " moving average", label=v)
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Price")
 
-for v in stock:
-    dataFrame["Flux_" + v] = (dataFrame[v] - dataFrame[v].shift(1)).fillna(0)
-    dataFrame["RSI_" + v] = (
-        dataFrame["Flux_" + v].rolling(center=False, window=15).apply(rsi).fillna(0)
-    )
+        avg = getMovingAvg(dataFrame[v], gap=20)
+        avg.plot(label="Moving Avg", ax=ax)
+        plt.show()
 
-for v in stock:
-    ax = dataFrame["RSI_" + v].plot(title="RSI " + v, label=v)
-    ax.set_xlabel("Date")
-    ax.set_ylabel("RSI value")
-    plt.show()
+    frame = copy.deepcopy(dataFrame)
+
+    for v in stock:
+        # Avg
+        avg = getMovingAvg(dataFrame[v], gap=20)
+
+        # Standard Deviation
+        std = dataFrame[v].rolling(20).std()
+        largeAvg = getMovingAvg(dataFrame[v], gap=50)
+        dataFrame["MovingAvg_" + v] = avg
+        dataFrame["Avg" + v] = largeAvg
+        dataFrame["RollStd_" + v] = std
+
+        # Bollinger Bands Limits (2*standard deviation, 20 as period)
+        up = avg + std * 2
+        low = avg - std * 2
+        dataFrame["Up_" + v] = up
+        dataFrame["Low_" + v] = low
+
+    for v in stock:
+        ax = dataFrame.plot(title="Bollinger Bands", label=v)
+        up.plot(label="up -", ax=ax)
+        low.plot(label="low -", ax=ax)
+        avg.plot(label="RollingMean", ax=ax)
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Price")
+        plt.show()
+
+    for v in stock:
+        daily = (dataFrame[v] / dataFrame[v].shift(1)) - 1
+        dataFrame["Daily_" + v] = daily
+        ax = daily.plot(title="Daily " + v, label=v)
+        plt.show()
+
+    for v in stock:
+        dataFrame["Flux_" + v] = (dataFrame[v] - dataFrame[v].shift(1)).fillna(0)
+        dataFrame["RSI_" + v] = (
+            dataFrame["Flux_" + v].rolling(center=False, window=15).apply(rsi).fillna(0)
+        )
+
+    for v in stock:
+        ax = dataFrame["RSI_" + v].plot(title="RSI " + v, label=v)
+        ax.set_xlabel("Date")
+        ax.set_ylabel("RSI value")
+        plt.show()

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from stock import rsi
+
+
+def test_rsi_all_gains():
+    series = pd.Series([1, 2, 3, 4])
+    result = rsi(series)
+    assert result == pytest.approx(100)
+
+
+def test_rsi_all_losses():
+    series = pd.Series([-1, -2, -3, -4])
+    result = rsi(series)
+    assert result == pytest.approx(0)
+
+
+def test_rsi_all_zeros():
+    series = pd.Series([0, 0, 0, 0])
+    result = rsi(series)
+    assert result == 0
+    assert not pd.isna(result)
+


### PR DESCRIPTION
## Summary
- Improve `rsi` function to avoid NaNs and zero-division for edge cases
- Move heavy imports and execution logic under a `__main__` guard
- Add pytest coverage for RSI gains, losses, and zero series scenarios

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a48612b8b883218cb5926a5730dfef